### PR TITLE
Add scatter helper script

### DIFF
--- a/game/levels/test_level/test_level.tscn
+++ b/game/levels/test_level/test_level.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://game/levels/level_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://game/objects/prototype/ground_green.tscn" type="PackedScene" id=2]
 [ext_resource path="res://game/objects/zone_switch_area.tscn" type="PackedScene" id=3]
 [ext_resource path="res://game/objects/prototype/cube_green.tscn" type="PackedScene" id=4]
+[ext_resource path="res://game/objects/helpers/scatter.gd" type="Script" id=5]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 35, 1, 35 )
@@ -11,13 +12,18 @@ extents = Vector3( 35, 1, 35 )
 [sub_resource type="BoxShape" id=2]
 extents = Vector3( 1, 2, 0.25 )
 
-[sub_resource type="SpatialMaterial" id=3]
+[sub_resource type="SpatialMaterial" id=5]
 flags_transparent = true
 albedo_color = Color( 0, 0, 0, 0.25098 )
 
 [sub_resource type="CubeMesh" id=4]
-material = SubResource( 3 )
+material = SubResource( 5 )
 size = Vector3( 2, 4, 0.5 )
+
+[sub_resource type="CubeMesh" id=6]
+
+[sub_resource type="SpatialMaterial" id=7]
+albedo_color = Color( 0.32549, 0.313726, 0.313726, 1 )
 
 [node name="TestLevel" instance=ExtResource( 1 )]
 
@@ -81,6 +87,15 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="DirectionalLight" type="DirectionalLight" parent="." index="3"]
+[node name="Rocks" type="Spatial" parent="." index="3"]
+script = ExtResource( 5 )
+extend = Vector3( 20, 0, 20 )
+instance_count = 5000
+min_scale = 0.01
+max_scale = 0.02
+mesh = SubResource( 6 )
+material_override = SubResource( 7 )
+
+[node name="DirectionalLight" type="DirectionalLight" parent="." index="4"]
 transform = Transform( 0.5, 0.612373, -0.612373, 0, 0.707107, 0.707107, 0.866025, -0.353553, 0.353553, 0, 10, 0 )
 light_energy = 0.5

--- a/game/objects/helpers/scatter.gd
+++ b/game/objects/helpers/scatter.gd
@@ -1,0 +1,78 @@
+tool
+extends Spatial
+
+class_name Scatter
+
+## This is a very simple scatter implementation.
+## This code allows you to quickly place a number of instances of a mesh at random locations.
+
+export var extend : Vector3 = Vector3(1.0, 0.0, 1.0) setget set_extend
+export var instance_count : int = 10 setget set_instance_count
+export var min_scale : float = 1.0 setget set_min_scale
+export var max_scale : float = 1.0 setget set_max_scale
+export var mesh : Mesh setget set_mesh
+export var material_override : Material setget set_material_override
+
+var dirty : bool = true
+var multi_mesh : MultiMesh
+var multi_mesh_instance : MultiMeshInstance
+
+func set_extend(new_value):
+	extend = new_value
+	_set_dirty()
+
+func set_instance_count(new_value):
+	instance_count = new_value
+	_set_dirty()
+
+func set_min_scale(new_value):
+	min_scale = new_value
+	_set_dirty()
+
+func set_max_scale(new_value):
+	max_scale = new_value
+	_set_dirty()
+
+func set_mesh(new_mesh):
+	mesh = new_mesh
+	if multi_mesh:
+		multi_mesh.mesh = mesh
+
+func set_material_override(new_material):
+	material_override = new_material
+	if multi_mesh_instance:
+		multi_mesh_instance.material_override = material_override
+
+func _set_dirty():
+	if !dirty:
+		dirty = true
+		call_deferred("_update_multimesh")
+
+func _update_multimesh():
+	if !dirty:
+		return
+	
+	multi_mesh.instance_count = instance_count
+	for i in instance_count:
+		var t : Transform
+		var s : float = rand_range(min_scale, max_scale)
+		t.basis = Basis().rotated(Vector3.UP, rand_range(-PI, PI)).scaled(Vector3(s, s, s))
+		t.origin = Vector3(rand_range(-extend.x, extend.x), rand_range(-extend.y, extend.y), rand_range(-extend.z, extend.z))
+		multi_mesh.set_instance_transform(i, t)
+	
+	dirty = false
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	multi_mesh = MultiMesh.new()
+	multi_mesh.transform_format = MultiMesh.TRANSFORM_3D
+	multi_mesh.mesh = mesh
+	
+	multi_mesh_instance = MultiMeshInstance.new()
+	multi_mesh_instance.multimesh = multi_mesh
+	multi_mesh_instance.material_override = material_override
+	add_child(multi_mesh_instance)
+	
+	# First time creating our multimesh
+	_update_multimesh()
+


### PR DESCRIPTION
This adds a simple scatter script and applies it to the test level:

![image](https://user-images.githubusercontent.com/1945449/215794815-3bdbabdb-e4ba-446d-be4e-95ecd0d57f30.png)

Could maybe use a proper mesh for the rocks as they are just boxes atm.

Internally this uses a multimesh so for low poly objects you can easily place tens of thousands of instances without breaking a sweat. 
It places these objects within a given area at random locations. These are determined at startup, we're not saving the locations, which may lead to a bit of a slowdown at startup if you go overboard with the numbers.

But I wanted to keep things simple.

For something more advanced I highly recommend https://github.com/HungryProton/scatter